### PR TITLE
Fix unhandled exception when `send-bytes` is called

### DIFF
--- a/src/HIDGogoExtension.java
+++ b/src/HIDGogoExtension.java
@@ -667,8 +667,8 @@ public class HIDGogoExtension extends DefaultClassManager {
       LogoList messageList = args[0].getList();
       byte[] message = new byte[64];
       for (int i = 0; i<messageList.size() && i < 64; i++) {
-        Object val = messageList.get(i);
-        int v = (Integer)val;
+        Double val = (Double)messageList.get(i);
+        int v = val.intValue();
         message[i] = (byte)v;
       }
       sendMessage(message);


### PR DESCRIPTION
When the `send-bytes` procedure is called, NetLogo displays an error dialog with the following message:

```
NetLogo is unable to supply you with more details about this error.  Please report the problem 
 at https://github.com/NetLogo/NetLogo/issues, or to bugs@ccl.northwestern.edu, and paste the 
contents of this window into your report. 


java.lang.ClassCastException: class java.lang.Double cannot be cast to class java.lang.Integer (java.lang.Double and java.lang.Integer are in module java.base of loader 'bootstrap')
 at gogohid.extension.HIDGogoExtension$SendBytes.perform(HIDGogoExtension.java:671)
 at org.nlogo.prim._extern.perform(_extern.java:36)
 at org.nlogo.nvm.Context.stepConcurrent(Context.java:107)
 at org.nlogo.nvm.ConcurrentJob.step(ConcurrentJob.scala:65)
 at org.nlogo.job.JobThread.runPrimaryJobs(JobThread.scala:133)
 at org.nlogo.job.JobThread.$anonfun$run$1(JobThread.scala:68)
 at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
 at scala.util.control.Exception$Catch.apply(Exception.scala:228)
 at org.nlogo.api.Exceptions$.handling(Exceptions.scala:41)
 at org.nlogo.job.JobThread.run(JobThread.scala:66)

NetLogo 6.3.0
main: org.nlogo.app.AppFrame
thread: JobThread
OpenJDK 64-Bit Server VM 17.0.3 (BellSoft; 17.0.3+7-LTS)
operating system: Linux 6.5.4-arch2-1 (amd64 processor)
Scala version 2.12.16
JOGL: (3D View not initialized)
OpenGL Graphics: (3D View not initialized)
model: Untitled

05:28:55.976 RuntimeErrorEvent (org.nlogo.app.App$$anon$4 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
05:28:55.972 AddJobEvent (org.nlogo.app.common.CommandLine) AWT-EventQueue-0
05:28:55.972 OutputEvent (org.nlogo.app.common.CommandLine) AWT-EventQueue-0
05:28:55.972 CompiledEvent (org.nlogo.window.CompilerManager) AWT-EventQueue-0
05:28:55.943 CompileMoreSourceEvent (org.nlogo.app.common.CommandLine) AWT-EventQueue-0
05:28:55.916 PeriodicUpdateEvent (org.nlogo.app.App$$anon$4 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
05:28:55.715 PeriodicUpdateEvent (org.nlogo.app.App$$anon$4 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
05:28:55.515 PeriodicUpdateEvent (org.nlogo.app.App$$anon$4 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
05:28:55.315 PeriodicUpdateEvent (org.nlogo.app.App$$anon$4 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
05:28:55.114 PeriodicUpdateEvent (org.nlogo.app.App$$anon$4 (org.nlogo.window.GUIWorkspace)) AWT-EventQueue-0
```
As shown in the message, the error is caused by attempting to cast `Double` to `Integer`, which is not allowed. This PR fixes the problem by using `Double.intValue()` to do the conversion instead.